### PR TITLE
Add Sentry support.

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -130,7 +130,7 @@
         },
         "babel-template": {
           "version": "6.15.0",
-          "from": "babel-template@>=6.14.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.15.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.15.0.tgz"
         },
         "babel-runtime": {
@@ -421,7 +421,7 @@
     },
     "chart.js": {
       "version": "1.1.1",
-      "from": "chart.js@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/chart.js/-/chart.js-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-1.1.1.tgz"
     },
     "classnames": {
@@ -478,7 +478,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
@@ -490,7 +490,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
@@ -1247,117 +1247,117 @@
     },
     "dateformat": {
       "version": "1.0.12",
-      "from": "dateformat@latest",
+      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "dependencies": {
         "get-stdin": {
           "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "meow": {
           "version": "3.7.0",
-          "from": "meow@>=3.3.0 <4.0.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "2.1.0",
-              "from": "camelcase-keys@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.1",
-                  "from": "camelcase@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.2.0",
-              "from": "decamelize@>=1.1.2 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
             },
             "loud-rejection": {
               "version": "1.6.0",
-              "from": "loud-rejection@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
               "dependencies": {
                 "currently-unhandled": {
                   "version": "0.4.1",
-                  "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
                   "dependencies": {
                     "array-find-index": {
                       "version": "1.0.2",
-                      "from": "array-find-index@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
                     }
                   }
                 },
                 "signal-exit": {
                   "version": "3.0.1",
-                  "from": "signal-exit@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
                 }
               }
             },
             "map-obj": {
               "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "from": "normalize-package-data@>=2.3.4 <3.0.0",
+              "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
               "dependencies": {
                 "hosted-git-info": {
                   "version": "2.1.5",
-                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                 },
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "from": "builtin-modules@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "5.3.0",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                 },
                 "validate-npm-package-license": {
                   "version": "3.0.1",
-                  "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                   "dependencies": {
                     "spdx-correct": {
                       "version": "1.0.2",
-                      "from": "spdx-correct@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                       "dependencies": {
                         "spdx-license-ids": {
                           "version": "1.2.2",
-                          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
                         }
                       }
                     },
                     "spdx-expression-parse": {
                       "version": "1.0.3",
-                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
                     }
                   }
@@ -1366,32 +1366,32 @@
             },
             "object-assign": {
               "version": "4.1.0",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "from": "read-pkg-up@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "dependencies": {
                     "path-exists": {
                       "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -1400,32 +1400,32 @@
                 },
                 "read-pkg": {
                   "version": "1.1.0",
-                  "from": "read-pkg@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.9",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "from": "parse-json@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                  "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                 }
                               }
@@ -1434,29 +1434,29 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "from": "strip-bom@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "from": "is-utf8@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                             }
                           }
@@ -1465,27 +1465,27 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.9",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
@@ -1498,27 +1498,27 @@
             },
             "redent": {
               "version": "1.0.0",
-              "from": "redent@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
               "dependencies": {
                 "indent-string": {
                   "version": "2.1.0",
-                  "from": "indent-string@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "2.0.1",
-                      "from": "repeating@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.2",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                             }
                           }
@@ -1529,14 +1529,14 @@
                 },
                 "strip-indent": {
                   "version": "1.0.1",
-                  "from": "strip-indent@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                 }
               }
             },
             "trim-newlines": {
               "version": "1.0.0",
-              "from": "trim-newlines@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
             }
           }
@@ -1961,7 +1961,7 @@
     },
     "jwt-decode": {
       "version": "2.1.0",
-      "from": "jwt-decode@latest",
+      "from": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.1.0.tgz"
     },
     "less": {
@@ -2092,6 +2092,18 @@
       "version": "0.2.2",
       "from": "https://registry.npmjs.org/qrcode-reader/-/qrcode-reader-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/qrcode-reader/-/qrcode-reader-0.2.2.tgz"
+    },
+    "raven-js": {
+      "version": "3.7.0",
+      "from": "raven-js@latest",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.7.0.tgz",
+      "dependencies": {
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        }
+      }
     },
     "react": {
       "version": "0.14.8",
@@ -2441,32 +2453,32 @@
     },
     "react-chartjs-2": {
       "version": "1.2.8",
-      "from": "react-chartjs-2@latest",
+      "from": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-1.2.8.tgz",
       "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-1.2.8.tgz",
       "dependencies": {
         "chart.js": {
           "version": "2.3.0",
-          "from": "chart.js@>=2.2.0-rc.1 <3.0.0",
+          "from": "https://registry.npmjs.org/chart.js/-/chart.js-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.3.0.tgz",
           "dependencies": {
             "chartjs-color": {
               "version": "2.0.0",
-              "from": "chartjs-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.0.0.tgz",
               "dependencies": {
                 "color-convert": {
                   "version": "0.5.3",
-                  "from": "color-convert@>=0.5.3 <0.6.0",
+                  "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                 },
                 "chartjs-color-string": {
                   "version": "0.4.0",
-                  "from": "chartjs-color-string@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.4.0.tgz",
                   "dependencies": {
                     "color-name": {
                       "version": "1.1.1",
-                      "from": "color-name@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                     }
                   }
@@ -2475,7 +2487,7 @@
             },
             "moment": {
               "version": "2.15.1",
-              "from": "moment@>=2.10.6 <3.0.0",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
             }
           }
@@ -2822,29 +2834,29 @@
     },
     "react-responsive": {
       "version": "1.1.5",
-      "from": "react-responsive@latest",
+      "from": "https://registry.npmjs.org/react-responsive/-/react-responsive-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-1.1.5.tgz",
       "dependencies": {
         "hyphenate-style-name": {
           "version": "1.0.1",
-          "from": "hyphenate-style-name@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.1.tgz"
         },
         "matchmedia": {
           "version": "0.1.2",
-          "from": "matchmedia@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/matchmedia/-/matchmedia-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/matchmedia/-/matchmedia-0.1.2.tgz",
           "dependencies": {
             "css-mediaquery": {
               "version": "0.1.2",
-              "from": "css-mediaquery@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.1.0",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }

--- a/app/package.json
+++ b/app/package.json
@@ -27,6 +27,7 @@
     "print-html-element": "0.3.4",
     "qr-image": "latest",
     "qrcode-reader": "0.2.2",
+    "raven-js": "^3.7.0",
     "react": "^0.14.6",
     "react-bootstrap": "^0.30.3",
     "react-chartjs-2": "^1.2.8",

--- a/app/src/script/index.js
+++ b/app/src/script/index.js
@@ -1,11 +1,9 @@
 require('../style/index.less');
 require('babel-polyfill');
 
-console.log('commit hash:', __COMMIT_HASH__);
-console.log('build number:', __BUILD_NUMBER__);
-console.log('build date:', __BUILD_DATE__);
-console.log('env:', __ENV__);
+var config = require('/opt/cocorico/app-web/config.json');
 
+var Raven = require('raven-js');
 var React = require('react');
 var ReactRouter = require('react-router');
 var ReactDOM = require('react-dom');
@@ -27,27 +25,52 @@ var Router = ReactRouter.Router,
 
   RouteAction = require('./action/RouteAction');
 
-browserHistory.listen((location, action) => {
-  RouteAction.change(browserHistory, location, action);
-});
-
 var messages = require('./intl/locale.js').getCurrentLocaleMessages();
 
-ReactDOM.render(
-  <Router history={browserHistory}>
-    <Route path="/" component={App}>
-      <IndexRoute component={Home}/>
-      <Route path={messages.route.SIGN_IN} component={Login}/>
-      <Route path={messages.route.SERVICE_STATUS} component={ServiceStatus}/>
-      <Route path="vote/:slug" component={VotePage}/>
-      <Route path={messages.route.BALLOT_BOX + '/:voteId'} component={BallotBox}/>
-    </Route>
-    <Route path="/embed" component={Embed}>
-      <Route path="vote-widget/:voteId" component={EmbedVoteWidgetPage}/>
-    </Route>
-    <Route path="/" component={App}>
-      <Route path=":slug" component={Page}/>
-    </Route>
-  </Router>,
-  document.getElementById('root')
-);
+function main() {
+  browserHistory.listen((location, action) => {
+    RouteAction.change(browserHistory, location, action);
+  });
+
+  return ReactDOM.render(
+    <Router history={browserHistory}>
+      <Route path="/" component={App}>
+        <IndexRoute component={Home}/>
+        <Route path={messages.route.SIGN_IN} component={Login}/>
+        <Route path={messages.route.SERVICE_STATUS} component={ServiceStatus}/>
+        <Route path="vote/:slug" component={VotePage}/>
+        <Route path={messages.route.BALLOT_BOX + '/:voteId'} component={BallotBox}/>
+      </Route>
+      <Route path="/embed" component={Embed}>
+        <Route path="vote-widget/:voteId" component={EmbedVoteWidgetPage}/>
+      </Route>
+      <Route path="/" component={App}>
+        <Route path=":slug" component={Page}/>
+      </Route>
+    </Router>,
+    document.getElementById('root')
+  );
+}
+
+console.log('commit hash:', __COMMIT_HASH__);
+console.log('build number:', __BUILD_NUMBER__);
+console.log('build date:', __BUILD_DATE__);
+console.log('env:', __ENV__);
+
+if (!!Raven) {
+  Raven
+    .config('https://' + config.sentry.public_key + '@sentry.io/' + config.sentry.project_id)
+    .install();
+  Raven.context(
+    {
+      release: __BUILD_NUMBER__,
+      environment: __ENV__,
+      tags: {
+        commit: __COMMIT_HASH__,
+      },
+    },
+    main
+  );
+} else {
+  main();
+}

--- a/provisioning/inventory/group_vars/all.yml
+++ b/provisioning/inventory/group_vars/all.yml
@@ -41,3 +41,7 @@ supported_locales:
 
 nodejs_nodesource_repository: https://deb.nodesource.com/node_4.x
 nodejs_version: 4.*
+
+sentry:
+  public_key: b4f860a54da0436eab32838de28d6514
+  project_id: 103204

--- a/provisioning/roles/app-web/templates/config.json.j2
+++ b/provisioning/roles/app-web/templates/config.json.j2
@@ -7,4 +7,7 @@
     "capabilities" : {{ capabilities | to_json }},
     "supportedWebBrowsers": {{ supported_web_browsers | to_json }},
     "supportedLocales": {{ supported_locales | to_json }}
+{% if sentry %}
+    , "sentry" : {{ sentry | to_json }}
+{% endif %}
 }


### PR DESCRIPTION
The current implementation uses the SaaS version of Sentry on sentry.io.
We should fix this and use a local instance for privacy reasons.
