### PR TITLE
Call remote webhooks on ballot success/failure

### DIFF
--- a/api/src/models/App.js
+++ b/api/src/models/App.js
@@ -12,6 +12,7 @@ App.add({
   title: { type: String, required: true, initial: true },
   secret: { type: Types.Key, required: true, default: () => srs(32).toLowerCase() },
   validURLs: { type: Types.TextArray },
+  webhookURL: { type: Types.Text },
 });
 
 App.relationship({ path: 'votes', ref: 'Vote', refPath: 'app' });

--- a/api/src/routes/api/ballot.js
+++ b/api/src/routes/api/ballot.js
@@ -117,6 +117,8 @@ exports.vote = function(req, res) {
         {
           id: ballot.id,
           app: vote.app,
+          vote: {id: vote.id},
+          user: {sub: req.user.sub},
           transaction: req.body.transaction,
           voteContractAddress: vote.voteContractAddress,
           voteContractABI: JSON.parse(vote.voteContractABI),

--- a/provisioning/provision.yml
+++ b/provisioning/provision.yml
@@ -15,3 +15,4 @@
     - { role: "queue-service", tags: ["blockchain", "database", "queue"] }
     - { role: "blockchain-worker", tags: ["blockchain", "worker"] }
     - { role: "blockchain", tags: ["blockchain", "database"] }
+    - { role: "webhook" }

--- a/provisioning/roles/webhook/tasks/main.yml
+++ b/provisioning/roles/webhook/tasks/main.yml
@@ -10,4 +10,10 @@
 - file: src={{ project_dir }}/{{ role_name }}/node_modules dest=/vagrant/{{ role_name }}/node_modules state=link
 
 - name: install npm modules
-  npm: path=/vagrant/webhook
+  npm: path=/vagrant/{{ role_name }}
+
+- name: install upstart script
+  template: src={{ role_name }}.upstart.conf.j2 dest=/etc/init/{{ project_name }}-{{ role_name }}.conf
+
+- name: start service
+  service: name=cocorico-webhook state=started

--- a/provisioning/roles/webhook/tasks/main.yml
+++ b/provisioning/roles/webhook/tasks/main.yml
@@ -1,0 +1,13 @@
+- set_fact: role_name=webhook
+
+- name: install nodejs
+  include: ../../../tasks/install_node.yml
+
+- name: create role directory
+  file: path={{ project_dir}}/{{ role_name }} state=directory
+
+- file: path={{ project_dir }}/{{ role_name }}/node_modules state=directory recurse=yes
+- file: src={{ project_dir }}/{{ role_name }}/node_modules dest=/vagrant/{{ role_name }}/node_modules state=link
+
+- name: install npm modules
+  npm: path=/vagrant/webhook

--- a/provisioning/roles/webhook/templates/webhook.upstart.conf.j2
+++ b/provisioning/roles/webhook/templates/webhook.upstart.conf.j2
@@ -1,0 +1,31 @@
+description "{{ project_name }}-{{ role_name }}"
+
+start on started {{ project_name }}-api-web
+stop on stopped {{ project_name }}-api-web
+
+expect fork
+respawn
+
+env NODE_ENV={{ environment_name }}
+
+{% if is_development_environment %}
+env NODE_TLS_REJECT_UNAUTHORIZED=0
+{% endif %}
+
+script
+    exec forever \
+        start \
+        -a \
+        -l {{ log_dir }}/{{ role_name }}.forever.log \
+        -o {{ log_dir }}/{{ role_name }}.log \
+        -e {{ log_dir }}/{{ role_name }}.error.log \
+        --pidFile /var/run/{{ project_name }}-{{ role_name }}.pid \
+        --sourceDir /vagrant/{{ role-name }} \
+        --workingDir /vagrant/{{ role-name }} \
+        index.js
+end script
+
+pre-stop script
+    rm /var/run/{{ project_name }}-{{ role_name }}.pid
+    exec forever stop /vagrant/{{ role-name }}/vote-queue-worker.js
+end script

--- a/provisioning/roles/webhook/templates/webhook.upstart.conf.j2
+++ b/provisioning/roles/webhook/templates/webhook.upstart.conf.j2
@@ -20,12 +20,12 @@ script
         -o {{ log_dir }}/{{ role_name }}.log \
         -e {{ log_dir }}/{{ role_name }}.error.log \
         --pidFile /var/run/{{ project_name }}-{{ role_name }}.pid \
-        --sourceDir /vagrant/{{ role-name }} \
-        --workingDir /vagrant/{{ role-name }} \
+        --sourceDir /vagrant/{{ role_name }} \
+        --workingDir /vagrant/{{ role_name }} \
         index.js
 end script
 
 pre-stop script
     rm /var/run/{{ project_name }}-{{ role_name }}.pid
-    exec forever stop /vagrant/{{ role-name }}/vote-queue-worker.js
+    exec forever stop /vagrant/{{ role_name }}/index.js
 end script

--- a/script/run-tests.sh
+++ b/script/run-tests.sh
@@ -13,3 +13,7 @@ popd
 pushd blockchain-worker
 npm install && npm test
 popd
+
+pushd webhook
+npm install && npm test
+popd

--- a/webhook/.eslintrc.js
+++ b/webhook/.eslintrc.js
@@ -1,0 +1,36 @@
+const OFF = 0;
+const WARNING = 1;
+const ERROR = 2;
+
+module.exports = {
+  parser: 'babel-eslint',
+
+  ecmaFeatures: {
+    modules: false
+  },
+
+  // We're stricter than the default config, mostly. We'll override a few rules.
+  rules: {
+    'accessor-pairs': OFF,
+    'brace-style': [ERROR, '1tbs'],
+    'comma-dangle': [ERROR, 'always-multiline'],
+    'consistent-return': ERROR,
+    'dot-location': [ERROR, 'property'],
+    'dot-notation': ERROR,
+    'eol-last': ERROR,
+    'eqeqeq': [ERROR, 'allow-null'],
+    'indent': [ERROR, 2, {SwitchCase: 1}],
+    'keyword-spacing': ERROR,
+    'no-bitwise': OFF,
+    'no-inner-declarations': [ERROR, 'functions'],
+    'no-multi-spaces': ERROR,
+    'no-restricted-syntax': [ERROR, 'WithStatement'],
+    'no-shadow': WARNING,
+    'no-unused-expressions': ERROR,
+    'no-unused-vars': [ERROR, {args: 'none'}],
+    'quotes': [ERROR, 'single', 'avoid-escape'],
+    'space-before-blocks': ERROR,
+    'space-before-function-paren': [ERROR, {anonymous: 'never', named: 'never'}],
+    'strict': [ERROR, 'global'],
+  }
+};

--- a/webhook/.gitignore
+++ b/webhook/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/webhook/index.js
+++ b/webhook/index.js
@@ -1,0 +1,71 @@
+var bunyan = require('bunyan');
+var request = require('superagent');
+var noCache = require('superagent-no-cache')
+
+var log = bunyan.createLogger({name: "webhook"});
+
+var RETRY_DELAY = 60;
+
+function assertMessageIsWebhookEvent(msg) {
+    return !!msg.event && !!msg.url && !!msg.createdAt;
+}
+
+require('amqplib/callback_api').connect(
+    'amqp://localhost',
+    (err, conn) => {
+        if (err != null) {
+            return log.error({error: err}, 'queue connection error');
+        }
+
+        conn.createChannel((err, ch) => {
+            if (err != null) {
+                return log.error({error: err}, 'queue channel creation error');
+            }
+
+            ch.assertQueue('webhooks');
+            ch.consume('webhooks', (msg) => {
+                if (msg !== null) {
+                    msg = JSON.parse(msg.content.toString());
+
+                    if (!assertMessageIsWebhookEvent(msg)) {
+                        // FIXME: major error here, should we stop the service ?
+                        log.error(
+                            { message: msg },
+                            'assertion failed: queue message is not a valid webhook'
+                        );
+                        return ;
+                    }
+
+                    log.info({ webhook: msg }, 'handling webhook');
+
+                    if (!!msg.lastTriedAt && (msg.lastTriedAt - msg.lastTriedAt > RETRY_DELAY)) {
+                        log.info({ webhook: msg }, 'delaying webhook');
+                        ch.nack(msg, false, true);
+                        return;
+                    }
+
+                    log.info({ webhook: msg }, 'calling webhook');
+
+                    request
+                        .user(noCache)
+                        .post(msg.url)
+                        .send({event: msg.event})
+                        .end((err, res) => {
+                            if (err) {
+                                return log.error({ error: err }, 'webhook error');
+                            }
+
+                            if (res.ok) {
+                                log.info({ status: res.status }, 'webhook call succeeded');
+                                ch.ack(msg);
+                            } else {
+                                log.info({ status: res.status }, 'webhook call failed');
+                                msg.lastTriedAt = Date.now() / 1000;
+                                ch.nack(msg, false, true);
+                            }
+                        });
+                }
+            });
+        });
+    }
+);

--- a/webhook/index.js
+++ b/webhook/index.js
@@ -1,71 +1,90 @@
 var bunyan = require('bunyan');
 var request = require('superagent');
-var noCache = require('superagent-no-cache')
 
-var log = bunyan.createLogger({name: "webhook"});
+var log = bunyan.createLogger({name: 'webhook'});
 
-var RETRY_DELAY = 60;
+var RETRY_DELAY = 60 * 1000;  // 1 minute in milliseconds
+var RETRY_TTL = 24 * 60 * 60 * 1000;  // 1 day in milliseconds
 
-function assertMessageIsWebhookEvent(msg) {
-    return !!msg.event && !!msg.url && !!msg.createdAt;
+function isWebhookEvent(content) {
+  return !!content.event && !!content.url && !!content.createdAt;
 }
 
-require('amqplib/callback_api').connect(
-    'amqp://localhost',
-    (err, conn) => {
-        if (err != null) {
-            return log.error({error: err}, 'queue connection error');
-        }
+require('amqplib/callback_api').connect('amqp://localhost', (err, conn) => {
+  if (err) {
+    log.error({error: err}, 'Failed to connect to message broker');
+    return;
+  }
 
-        conn.createChannel((err, ch) => {
-            if (err != null) {
-                return log.error({error: err}, 'queue channel creation error');
-            }
-
-            ch.assertQueue('webhooks');
-            ch.consume('webhooks', (msg) => {
-                if (msg !== null) {
-                    msg = JSON.parse(msg.content.toString());
-
-                    if (!assertMessageIsWebhookEvent(msg)) {
-                        // FIXME: major error here, should we stop the service ?
-                        log.error(
-                            { message: msg },
-                            'assertion failed: queue message is not a valid webhook'
-                        );
-                        return ;
-                    }
-
-                    log.info({ webhook: msg }, 'handling webhook');
-
-                    if (!!msg.lastTriedAt && (msg.lastTriedAt - msg.lastTriedAt > RETRY_DELAY)) {
-                        log.info({ webhook: msg }, 'delaying webhook');
-                        ch.nack(msg, false, true);
-                        return;
-                    }
-
-                    log.info({ webhook: msg }, 'calling webhook');
-
-                    request
-                        .user(noCache)
-                        .post(msg.url)
-                        .send({event: msg.event})
-                        .end((err, res) => {
-                            if (err) {
-                                return log.error({ error: err }, 'webhook error');
-                            }
-
-                            if (res.ok) {
-                                log.info({ status: res.status }, 'webhook call succeeded');
-                                ch.ack(msg);
-                            } else {
-                                log.info({ status: res.status }, 'webhook call failed');
-                                msg.lastTriedAt = Date.now() / 1000;
-                                ch.nack(msg, false, true);
-                            }
-                        });
-                }
-            });
-        });
+  conn.createChannel((err2, ch) => {
+    if (err2) {
+      log.error({error: err}, 'Failed to create message channel');
+      return;
     }
-);
+
+    ch.assertQueue('webhooks');
+    ch.consume('webhooks', (msg) => {
+      msg.content = JSON.parse(msg.content.toString());
+
+      // Delay messages already processed recently
+      if (!!msg.content.lastTriedAt) {
+        var elapsedTime = Date.now() - msg.content.lastTriedAt;
+        if (elapsedTime < RETRY_DELAY) {
+          ch.nack(msg);  // append message back to queue
+          return;
+        }
+      }
+
+      // Skip messages failing for too long
+      if (!!msg.content.firstTriedAt) {
+        var elapsedTime = Date.now() - msg.content.firstTriedAt;
+        if (elapsedTime > RETRY_TTL) {
+          log.error({ message: msg },
+            'Message failed for too long, skipping');
+          ch.ack(msg);
+          return;
+        }
+      }
+
+      // Skip invalid messages
+      if (!isWebhookEvent(msg.content)) {
+        log.error({ message: msg }, 'Invalid message, skipping');
+        ch.ack(msg);
+        return;
+      }
+
+      // Send HTTP request to remote webhook
+      log.info({ message: msg }, 'Calling webhook');
+      request
+        .post(msg.content.url)
+        .send({event: msg.content.event})
+        .end((err3, res) => {
+          if (err3 || res.error) {
+            if (err3) {
+              log.error({ error: err3 },
+                'Failed to call webhook, retrying later');
+            } else if (res.error) {
+              log.error({ http_status: res.status },
+                'Failed to call webhook, retrying later');
+            }
+            if (!msg.content.firstTriedAt) {
+              msg.content.firstTriedAt = Date.now();
+            }
+            msg.content.lastTriedAt = Date.now();
+            // Requeue updated message
+            ch.sendToQueue('webhooks',
+              new Buffer(JSON.stringify(msg.content)),
+              { persistent : true }
+            )
+            ch.ack(msg);
+            return;
+          }
+
+          log.info({ http_status: res.status },
+            'Webhook call succeeded');
+          ch.ack(msg);
+        })
+      ;
+    });
+  });
+});

--- a/webhook/package.json
+++ b/webhook/package.json
@@ -3,14 +3,20 @@
   "version": "0.0.1",
   "description": "",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "amqplib": "^0.4.2",
+    "bunyan": "1.8.0",
     "superagent": "^2.2.0",
     "superagent-no-cache": "^0.1.0"
+  },
+  "scripts": {
+      "start": "service cocorico-webhook stop ; nodemon -w src -d 5 ./index.js",
+      "test": "eslint ."
+  },
+  "devDependencies": {
+    "babel-eslint": "^6.1.2",
+    "eslint": "^3.6.0"
   }
 }

--- a/webhook/package.json
+++ b/webhook/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cocorico-webhook",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "amqplib": "^0.4.2",
+    "superagent": "^2.2.0",
+    "superagent-no-cache": "^0.1.0"
+  }
+}


### PR DESCRIPTION
Changes:
- App model gets a new webhookURL field.
- After each ballot attempt, successful or not, a message is appended to the webhook queue.
- An always-running worker consumes webhook messages and, for each of them, call the remote URL.
- Failing webhooks are retried every minute for 24 hours.
- Webhook code is covered by CI.

Known problems:
- No worker reconnect to RabbitMQ in case of dropped connection.
- The ballot worker connects to RabbitMQ for each webhook message to publish.
- Webhooks are called one after the other. No parallelism.
- The retry mechanism is extremely costly, due to:
  - messages being checked for their retry TTL continuously and
  - messages needing to be parsed/serialised from/to JSON each time.
- The retry mechanism is pretty basic. Instead the retry delay could:
  - grow over time,
  - differ depending on HTTP error.
