### PR TITLE
Fork the blockchain workers.

### DIFF
--- a/blockchain-worker/package.json
+++ b/blockchain-worker/package.json
@@ -16,8 +16,8 @@
     "npm": ">=1.3.14"
   },
   "scripts": {
-      "vote": "service cocorico-blockchain-worker-vote stop ; nodemon -w src -d 5 ./src/vote-queue-worker.js",
-      "ballot": "service cocorico-blockchain-worker-ballot stop ; nodemon -w src -d 5 ./src/ballot-queue-worker.js",
+      "vote": "service cocorico-blockchain-worker-vote stop ; nodemon -w src -d 5 ./src/vote.js",
+      "ballot": "service cocorico-blockchain-worker-ballot stop ; nodemon -w src -d 5 ./src/ballot.js",
       "test": "eslint ."
   },
   "devDependencies": {

--- a/blockchain-worker/src/ballot.js
+++ b/blockchain-worker/src/ballot.js
@@ -1,0 +1,35 @@
+var config = require('/opt/cocorico/api-web/config.json');
+
+var cluster = require('cluster');
+var bunyan = require('bunyan');
+
+var log = bunyan.createLogger({name: 'ballot-service'});
+
+if (cluster.isMaster) {
+
+  log.info('spawning consumers');
+
+  for (var i = 0; i < config.ballotConsumerCount; i++) {
+    cluster.fork();
+  }
+
+  log.info('consumers started');
+
+  // If a worker exits, we wait 30 seconds and restart it.
+  cluster.on('exit', (deadWorker, code, signal) => {
+    log.info({workerId: deadWorker.id}, 'consumer exited, waiting 30s');
+
+    setTimeout(
+      () => {
+        var newWorker = cluster.fork();
+
+        log.info({workerId: newWorker.id}, 'restarted consumer');
+      },
+      30000
+    );
+  });
+} else {
+  var ballotConsumer = require('./ballot-consumer');
+
+  ballotConsumer.run();
+}

--- a/blockchain-worker/src/vote-consumer.js
+++ b/blockchain-worker/src/vote-consumer.js
@@ -5,8 +5,9 @@ var Web3 = require('web3');
 var fs = require('fs');
 var md5 = require('md5');
 var bunyan = require('bunyan');
+var cluster = require('cluster');
 
-var log = bunyan.createLogger({name: 'vote-queue-worker'});
+var log = bunyan.createLogger({name: 'vote-consumer-' + cluster.worker.id});
 
 keystone.init({'mongo' : config.mongo.uri});
 keystone.mongoose.connect(config.mongo.uri);
@@ -31,7 +32,7 @@ function getCompiledVoteContract(web3, callback) {
       );
     }
 
-    callback(error, compiled);
+    callback(error, !!compiled.Vote ? compiled.Vote : compiled);
   });
 }
 
@@ -50,8 +51,8 @@ function mineVoteContract(next) {
         (err, accounts) => callback(err, accounts, compiled)
       ),
       (accounts, compiled, callback) => {
-        var code = compiled.Vote.code;
-        var abi = compiled.Vote.info.abiDefinition;
+        var code = compiled.code;
+        var abi = compiled.info.abiDefinition;
 
         log.info(
           { address: accounts[0] },

--- a/blockchain-worker/src/vote.js
+++ b/blockchain-worker/src/vote.js
@@ -1,0 +1,35 @@
+var config = require('/opt/cocorico/api-web/config.json');
+
+var cluster = require('cluster');
+var bunyan = require('bunyan');
+
+var log = bunyan.createLogger({name: 'vote-service'});
+
+if (cluster.isMaster) {
+
+  log.info('spawning consumers');
+
+  for (var i = 0; i < config.voteConsumerCount; i++) {
+    cluster.fork();
+  }
+
+  log.info('consumers started');
+
+  // If a worker exits, we wait 30 seconds and restart it.
+  cluster.on('exit', (deadWorker, code, signal) => {
+    log.info({workerId: deadWorker.id}, 'consumer exited, waiting 30s');
+
+    setTimeout(
+      () => {
+        var newWorker = cluster.fork();
+
+        log.info({workerId: newWorker.id}, 'restarted consumer');
+      },
+      30000
+    );
+  });
+} else {
+  var voteConsumer = require('./vote-consumer');
+
+  voteConsumer.run();
+}

--- a/provisioning/inventory/group_vars/all.yml
+++ b/provisioning/inventory/group_vars/all.yml
@@ -45,3 +45,6 @@ nodejs_version: 4.*
 sentry:
   public_key: b4f860a54da0436eab32838de28d6514
   project_id: 103204
+
+ballot_consumer_count: 8
+vote_consumer_count: 8

--- a/provisioning/roles/api-web/templates/config.json.j2
+++ b/provisioning/roles/api-web/templates/config.json.j2
@@ -8,6 +8,8 @@
     "mongo" : {
       "uri" : "mongodb://{{ home_db_private_host }}/{{ mongodb_database_name }}"
     },
+    "ballotConsumerCount": {{ ballot_consumer_count }},
+    "voteConsumerCount": {{ vote_consumer_count }},
     "uploadDir" : "{{ home_web_upload_dir }}",
     "capabilities" : {{ capabilities | to_json }},
     "blockchain" : {

--- a/provisioning/roles/blockchain-worker/templates/blockchain-worker-ballot.upstart.conf.j2
+++ b/provisioning/roles/blockchain-worker/templates/blockchain-worker-ballot.upstart.conf.j2
@@ -22,10 +22,10 @@ script
         --pidFile /var/run/{{ project_name }}-{{ role_name }}-ballot.pid \
         --sourceDir /vagrant/blockchain-worker/src \
         --workingDir /vagrant/blockchain-worker/src \
-        ballot-queue-worker.js
+        ballot.js
 end script
 
 pre-stop script
     rm /var/run/{{ project_name }}-{{ role_name }}-ballot.pid
-    exec forever stop /vagrant/blockchain-worker/src/ballot-queue-worker.js
+    exec forever stop /vagrant/blockchain-worker/src/ballot.js
 end script

--- a/provisioning/roles/blockchain-worker/templates/blockchain-worker-vote.upstart.conf.j2
+++ b/provisioning/roles/blockchain-worker/templates/blockchain-worker-vote.upstart.conf.j2
@@ -22,10 +22,10 @@ script
         --pidFile /var/run/{{ project_name }}-{{ role_name }}-vote.pid \
         --sourceDir /vagrant/blockchain-worker/src \
         --workingDir /vagrant/blockchain-worker/src \
-        vote-queue-worker.js
+        vote.js
 end script
 
 pre-stop script
     rm /var/run/{{ project_name }}-{{ role_name }}-vote.pid
-    exec forever stop /vagrant/blockchain-worker/src/vote-queue-worker.js
+    exec forever stop /vagrant/blockchain-worker/src/vote.js
 end script


### PR DESCRIPTION
Fixes #62 and #53.
We need to be able to handle multiple ballot/vote at the same time.
To do this, we need to have multiple queue consumers. And thus, we just fork the corresponding NodeJS programs (issue #62).
The number of forks can be configured at provisioning by setting the ballot_consumer_count and vote_consumer_count Ansible facts.
Each fork will also be restarted automatically when the process 'exit' event is triggered. As a consequence, workers will automatically restart and try to reconnect to the queue when the queue itself crashes / is restarted (issue #53).
