### PR TITLE
Add a cron job to remove old ethash DAG files.

### DIFF
--- a/provisioning/roles/blockchain/tasks/main.yml
+++ b/provisioning/roles/blockchain/tasks/main.yml
@@ -59,6 +59,13 @@
 - name: install miner upstart script
   template: src=blockchain-miner.upstart.conf.j2 dest=/etc/init/cocorico-blockchain-miner.conf
 
+- name: setup cron job to remove old ethash DAG files
+  cron:
+    name: "remove old ethash DAG files"
+    state: present
+    special_time: daily
+    job: "ls -1t /root/.ethash/* | sed -e '1,2d' | xargs -d '\n' rm"
+
 - name: start the ethereum blockchain service
   service: name=cocorico-blockchain state=started
   when: not ethereum_mine_on_boot

--- a/provisioning/roles/blockchain/tasks/main.yml
+++ b/provisioning/roles/blockchain/tasks/main.yml
@@ -64,7 +64,7 @@
     name: "remove old ethash DAG files"
     state: present
     special_time: daily
-    job: "ls -1t /root/.ethash/* | sed -e '1,2d' | xargs -d '\n' rm"
+    job: "ls -1t /root/.ethash/* | sed -e '1,2d' | xargs rm"
 
 - name: start the ethereum blockchain service
   service: name=cocorico-blockchain state=started


### PR DESCRIPTION
Ethereum generates DAG files: https://github.com/ethereum/wiki/wiki/Ethash-DAG
They can take a lot of disk space.
The daily cron job will remove all ethash DAG files except the two most recent ones.
