### PR TITLE
Update Apache config to handle cache properly.

### DIFF
--- a/app/src/script/store/BallotStore.jsx
+++ b/app/src/script/store/BallotStore.jsx
@@ -8,8 +8,6 @@ var BallotAction = require('../action/BallotAction');
 
 module.exports = Reflux.createStore({
   init: function() {
-    jquery.ajaxSetup({ cache: false });
-
     this.listenTo(BallotAction.send, this._vote);
     // this.listenTo(BallotAction.cancel, this._unvote);
     this.listenTo(BallotAction.startPolling, this._startPollingBallot);

--- a/app/src/script/store/TransactionStore.jsx
+++ b/app/src/script/store/TransactionStore.jsx
@@ -5,8 +5,6 @@ var BallotAction = require('../action/BallotAction');
 
 module.exports = Reflux.createStore({
   init: function() {
-    jquery.ajaxSetup({ cache: false });
-
     this.listenTo(BallotAction.getTransactions, this._fetchByVoteId);
     this.listenTo(BallotAction.searchTransactions, this._fetchByVoteId);
 

--- a/provisioning/roles/api-web/templates/api-web.apache.conf.j2
+++ b/provisioning/roles/api-web/templates/api-web.apache.conf.j2
@@ -6,6 +6,11 @@ ProxyPreserveHost   On
 <LocationMatch "/api/">
     ProxyPass           http://127.0.0.1:3000/ retry=0
     ProxyPassReverse    http://127.0.0.1:3000/
+
+    # Remove cache on our API calls
+    Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+    Header set Pragma "no-cache"
+    Header set Expires "Wed, 11 Jan 1984 05:00:00 GMT"
 </LocationMatch>
 
 <LocationMatch "/admin">

--- a/provisioning/roles/app-web/templates/app-web.apache.conf.j2
+++ b/provisioning/roles/app-web/templates/app-web.apache.conf.j2
@@ -1,6 +1,9 @@
 <Directory "{{ www_dir }}">
     Options FollowSymLinks
 
+    Header set Cache-Control "public, must-revalidate"
+    Header set Expires "Wed, 11 Jan 1984 05:00:00 GMT"
+
     RewriteEngine On
     RewriteBase /
 

--- a/provisioning/roles/front-web/templates/cocorico-front-web.conf.j2
+++ b/provisioning/roles/front-web/templates/cocorico-front-web.conf.j2
@@ -63,9 +63,11 @@
     AddOutputFilterByType DEFLATE application/x-javascript
 
     # Cache control
-    <FilesMatch "\.(ico|pdf|flv|jpg|jpeg|png|gif|css|html)$">
+    <FilesMatch "\.(ico|pdf|flv|jpg|jpeg|png|gif|js|css|swf|data|mem|scene|html)$">
         Header unset Cache-Control
         Header set Cache-Control "max-age=290304000, public"
+        Header unset ETag
+        FileETag none
     </FilesMatch>
 
 </VirtualHost>


### PR DESCRIPTION
Fixes #59.
The API Apache configuration now has cache disabled.
The Web app has cache enabled, but we force it to revalidate.
Other assets have the cache enabled.
