### PR TITLE
Fix the firewall to allow both HTTP and HTTPS.

### DIFF
--- a/provisioning/roles/firewall/templates/firewall.j2
+++ b/provisioning/roles/firewall/templates/firewall.j2
@@ -46,8 +46,9 @@ iptables -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
 # SSH
 iptables -A INPUT -p tcp --dport ssh -j ACCEPT
 
-# HTTP
-iptables -A INPUT -p tcp --dport {{ http_protocol_prefix }} -j ACCEPT
+# HTTP(S)
+iptables -A INPUT -p tcp --dport http -j ACCEPT
+iptables -A INPUT -p tcp --dport https -j ACCEPT
 
 # Show current rules
 iptables -L


### PR DESCRIPTION
Without HTTP support, the initial HTTP connection cannot be established and upgraded to HTTPS.
